### PR TITLE
Feature/issue@1

### DIFF
--- a/lib/xsltproc.js
+++ b/lib/xsltproc.js
@@ -26,6 +26,8 @@ exports.transform = function(stylesheet, file, options) {
   args.push(stylesheet);
   args.push(file);
 
+  console.log(args);
+
   try {
     cmd = which(cmd);
   } catch (err) {
@@ -72,6 +74,11 @@ exports.getArgs = function(options) {
   // skip the DTD loading phase
   if (options && typeof options.novalid !== 'undefined') {
     args.push('--novalid');
+  }
+
+  // the input string param, only one
+  if (options && typeof options.stringparam !== 'undefined') {
+      args.push('--stringparam', options.stringparam.key, options.stringparam.val);
   }
 
   //  dump profiling informations

--- a/lib/xsltproc.js
+++ b/lib/xsltproc.js
@@ -26,8 +26,6 @@ exports.transform = function(stylesheet, file, options) {
   args.push(stylesheet);
   args.push(file);
 
-  console.log(args);
-
   try {
     cmd = which(cmd);
   } catch (err) {

--- a/test/fixtures/html.xsl
+++ b/test/fixtures/html.xsl
@@ -2,7 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
   <xsl:output method="html" version="4.0" encoding="utf-8"/>
-  
+
   <xsl:template match="page">
     <html>
       <head>

--- a/test/fixtures/txt.xsl
+++ b/test/fixtures/txt.xsl
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-  <xsl:output encoding="utf-8" indent="no" method="text"/>
-  
+  <xsl:output encoding="utf-8" indent="no" method="html"/>
+
   <xsl:template match="page">
-    <xsl:value-of select="@title"/>
+    <h1><xsl:value-of select="@title"/></h1>
+    <h2><xsl:value-of select="$title"/></h2>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/test/fixtures/txt.xsl
+++ b/test/fixtures/txt.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 
-  <xsl:output encoding="utf-8" indent="no" method="html"/>
+  <xsl:output encoding="utf-8" indent="no" method="text"/>
 
   <xsl:template match="page">
     <h1><xsl:value-of select="@title"/></h1>

--- a/test/xsltproc_test.js
+++ b/test/xsltproc_test.js
@@ -8,7 +8,14 @@ it("should return the correct TXT", function (done) {
 
   var xsl = '../xsltproc/test/fixtures/txt.xsl',
       xml = '../xsltproc/test/fixtures/data.xml',
-      xslt = xsltproc.transform(xsl, xml);
+      opts = {
+          "output": "test/fixtures/test.html",
+          "stringparam": {
+             "key": 'title',
+             "val": 'This is a single parameter passed as subtitle----anvidsahviulasdhvklasdbcuw'
+          }
+      },
+      xslt = xsltproc.transform(xsl, xml, opts);
 
   xslt.on('exit', function (code) {
     chai.assert.equal(code, 0, 'xsltproc process exited with code ' + code);


### PR DESCRIPTION
--stringparameter argument is also passed if is present inside options the object
`
stringparameter: {key:'param_name', val:'param_value'}
`

Only one stringparameter is accepted!!
